### PR TITLE
#131 fix incompatibility with remote storage

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -40,6 +40,11 @@
             <argument name="cronconfig" xsi:type="object">MageMojoCronConfig</argument>
         </arguments>
     </type>
-
+    <!-- https://github.com/magemojo/m2-ce-cron/issues/131 -->
+    <type name="Magento\Framework\App\MaintenanceMode">
+        <arguments>
+            <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem</argument>
+        </arguments>
+    </type>
 </config>
 


### PR DESCRIPTION
Fixes https://github.com/magemojo/m2-ce-cron/issues/131
Remote Storage implementation uses a caching mechanism incompatible with the cron service